### PR TITLE
Use internal cache if external cache fails

### DIFF
--- a/app/src/main/java/net/gaast/giggity/Fetcher.java
+++ b/app/src/main/java/net/gaast/giggity/Fetcher.java
@@ -114,6 +114,9 @@ public class Fetcher {
 				}
 
 				fntmp = new File(app.getExternalCacheDir(), "tmp." + Schedule.hashify(url));
+				if (!fntmp.canWrite()) {
+					fntmp = new File(app.getCacheDir(),  "tmp." + Schedule.hashify(url));
+				}
 				OutputStream copy = new FileOutputStream(fntmp);
 				inStream = new TeeInputStream(inStream, copy, true);  // true == close copy on close
 


### PR DESCRIPTION
This commits checks whether it's possible to write in the external cache and if not, it uses the internal cache.