### PR TITLE
Make the tent name column wider

### DIFF
--- a/app/src/main/java/net/gaast/giggity/BlockSchedule.java
+++ b/app/src/main/java/net/gaast/giggity/BlockSchedule.java
@@ -77,7 +77,7 @@ public class BlockSchedule extends LinearLayout implements NestedScroller.Listen
 	private int HourWidth = 96;
 	private int HourHeight = 15;
 	private int TentHeight = 48;
-	private int TentWidth = 36;
+	private int TentWidth = 64;
 	private final float fontSizeSmall = 12;
 	private float fontSize = 12; // scaled/configurable
 	


### PR DESCRIPTION
This makes UI bit nicer when tent names are reasonable length.

Ideally the width should be based on the longest tent name string length (with a max limit) but for now this quick fix improves the UI substantially for longer names (eg. LCA2017).
