### PR TITLE
Adding support for FOSSASIA open event JSON format

### DIFF
--- a/app/src/main/java/net/gaast/giggity/Schedule.java
+++ b/app/src/main/java/net/gaast/giggity/Schedule.java
@@ -534,7 +534,7 @@ public class Schedule {
 
 				//Getting value (latitude and longitude) from the map by key (name)
 
-				if (hasMicrolocs) {
+				if (hasMicrolocs && line.getTitle()!=null && !line.getTitle().equals("")) {
 					String locString = locs.get(line.getTitle());
 					String latitude = locString.substring(0, locString.indexOf(','));
 					String longitude = locString.substring(locString.indexOf(',') + 1);

--- a/app/src/main/java/net/gaast/giggity/Schedule.java
+++ b/app/src/main/java/net/gaast/giggity/Schedule.java
@@ -559,8 +559,8 @@ public class Schedule {
 			}
 
 		} catch (JSONException e) {
-			Log.w("JSON parsing", " Unable to parse ", e);
 			e.printStackTrace();
+			throw new LoadException("Parse error: " + e);
 		}
 	}
 

--- a/app/src/main/java/net/gaast/giggity/Schedule.java
+++ b/app/src/main/java/net/gaast/giggity/Schedule.java
@@ -428,7 +428,7 @@ public class Schedule {
 	private void loadJson(BufferedReader in) {
 
 		StringBuffer buffer = new StringBuffer();
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         HashMap<String, Schedule.Line> tentMap = new HashMap<String, Schedule.Line>();
 		Boolean hasMicrolocs = false;
 		Scanner s = new Scanner(in);
@@ -513,13 +513,11 @@ public class Schedule {
 				String endTimeS = event.getString("end_time");
 				Date startTime, endTime;
 
-                startTimeS = startTimeS.replace('T', ' ');
                 if (startTimeS.contains("+")) {
                     startTimeS = startTimeS.substring(0, startTimeS.lastIndexOf('+'));
                 }
                 startTimeS = startTimeS.substring(0, startTimeS.lastIndexOf('-'));
 
-                endTimeS = endTimeS.replace('T', ' ');
                 if (endTimeS.contains("+")) {
                     endTimeS = endTimeS.substring(0, endTimeS.lastIndexOf('+'));
                 }

--- a/giggity.iml
+++ b/giggity.iml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/giggity.iml
+++ b/giggity.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
FOSSASIA's open event JSON format contains information about rooms, icon and other web links which has to be added separately for the formats like pentabarf along with sessions.

Please see this issue for reference https://github.com/Wilm0r/giggity/issues/14

App could be tested for this API end point https://open-event-dev.herokuapp.com/api/v1/events/266?include=sessions,microlocations

See the endpoints's response here http://jsonviewer.stack.hu/#http://open-event-dev.herokuapp.com/api/v1/events/266?include=sessions,microlocations .

I have modified app so it automatically fetches the information of locations, sessions and icon's link from this endpoint itself.