### PR TITLE
Add the bump_menu_rev shell tool

### DIFF
--- a/tools/bump_menu_rev.sh
+++ b/tools/bump_menu_rev.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed -e "2s/\(^\t\"version\": \).*$/\1$(date '+%Y%m%d01'),/;" -i app/src/main/res/raw/menu.json && git add app/src/main/res/raw/menu.json && git commit -m "Bump menu revision"


### PR DESCRIPTION
It just updates the menu revision with the current date, and creates a
commit for this.

It doesn't check if the actual counter needs to be incremented if date
is the same, but it doesn't seem to be needed yet.