### PR TITLE
Also share speakers and weblinks

### DIFF
--- a/app/src/main/java/net/gaast/giggity/EventDialog.java
+++ b/app/src/main/java/net/gaast/giggity/EventDialog.java
@@ -47,6 +47,7 @@ import android.widget.TextView;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.StringJoiner;
 
 /* Mind you, one day this was an actual Dialog, but not anymore technically. It's just a pretty
    densely populated view used in two different ways (depending on whether we're on a tablet. */
@@ -306,9 +307,17 @@ public class EventDialog extends FrameLayout {
 			String time = android.text.format.DateUtils.formatDateRange(
 				ctx_, item_.getStartTime().getTime(), item_.getEndTime().getTime(),
 				DateUtils.FORMAT_24HOUR | DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME);
+
+			StringJoiner speakers = new StringJoiner(", ");
+			for (String speaker: item_.getSpeakers()) {
+				speakers.add(speaker);
+			}
+			
 			t.putExtra(android.content.Intent.EXTRA_TEXT,
 				item_.getSchedule().getTitle() + ": " + item_.getTitle() + "\n" +
 				item_.getLine().getTitle() + ", " + time + "\n" +
+				speakers + "\n" +
+				item_.getWebLink() + "\n" +
 				"\n" +
 				item_.getDescriptionStripped());
 

--- a/app/src/main/java/net/gaast/giggity/Schedule.java
+++ b/app/src/main/java/net/gaast/giggity/Schedule.java
@@ -1159,7 +1159,7 @@ public class Schedule {
 					}
 				}
 			} else if (localName.equals("event")) {
-				String id, title, startTimeS, durationS, s, desc;
+				String id, title, startTimeS, durationS, s, desc, wl;
 				Calendar startTime, endTime;
 				Schedule.Item item;
 				
@@ -1199,6 +1199,11 @@ public class Schedule {
 				if ((s = propMap.get("subtitle")) != null) {
 					if (!s.isEmpty())
 						item.setSubtitle(s);
+				}
+				
+				if ((wl = propMap.get("url")) != null) {
+					if (!wl.isEmpty())
+						item.setWebLink(wl);
 				}
 				
 				desc = "";
@@ -1353,6 +1358,7 @@ public class Schedule {
 		private LinkedList<Schedule.Link> links;
 		private LinkedList<String> speakers;
 		private String language;
+		private String webLink;
 		
 		private boolean remind;
 		private boolean hidden;
@@ -1427,6 +1433,14 @@ public class Schedule {
 		
 		public String getUrl() {
 			return (getSchedule().getUrl() + "#" + getId()); 
+		}
+
+		public String getWebLink() {
+			return webLink;
+		}
+
+		public void setWebLink(String webLink) {
+			this.webLink = webLink;
 		}
 		
 		public String getTitle() {


### PR DESCRIPTION
This includes speakers and a weblink in the shared information.
The weblink is a newly introduced concept as is supposed to represent the URL where the event is accessible on the web.
I would have prefered to call this `URL` but the `url` field already fulfills a different role.

This new field is only parsed from Pentabarf files, but should be generalizable.
(I am willing to implement it for the other formats)