### PR TITLE
Add LIT 2018 (will take place on April 21th)

### DIFF
--- a/app/src/main/res/raw/menu.json
+++ b/app/src/main/res/raw/menu.json
@@ -1,5 +1,5 @@
 {
-	"version": 2018021700,
+	"version": 2018032200,
 	"schedules": [
 		{
 			"version": 2017041700,
@@ -543,6 +543,22 @@
 					{
 						"url": "https://wiki.linux.conf.au/wiki/Main_Page",
 						"title": "Wiki"
+					}
+				]
+			}
+		},
+		{
+			"version": 2018032200,
+			"url": "https://frab.luga.de/de/LIT2018/public/schedule.xml",
+			"title": "Augsburger Linux-Infotag 2018",
+			"start": "2018-04-21",
+			"end": "2018-04-21",
+			"metadata": {
+				"icon": "https://luga-ev.github.io/frab-extras/Tux2.png",
+				"links": [
+					{
+						"url": "https://www.luga.de/Aktionen/LIT-2018/",
+						"title": "Website"
 					}
 				]
 			}


### PR DESCRIPTION
This pull request adds the entry for the Augsburger Linux-Infotag 2018. The 2017 installment was included in Giggity; we hope that this event will be included as well.

Please let me know
* if I should change the pull request to not change the global version number or
* if I should roll up the open pull requests by other contributors into a single one so that you have an easier time merging. :-)

Thank you!