### PR TITLE
short-term (starting tomorrow): Add Linuxwochen Wien 2018

### DIFF
--- a/app/src/main/res/raw/menu.json
+++ b/app/src/main/res/raw/menu.json
@@ -1,5 +1,5 @@
 {
-	"version": 2018032101,
+	"version": 2018050301,
 	"schedules": [
 		{
 			"version": 2017041700,
@@ -625,6 +625,26 @@
 					{
 						"name": ".*34-.*",
 						"latlon": [42.36111, -71.09194]
+					}
+				]
+			}
+		},
+		{
+			"version": 2018050300,
+			"url": "https://cfp.linuxwochen.at/de/LWW18/public/schedule.xml",
+			"title": "Linuxwochen Wien 2018",
+			"start": "2018-05-03",
+			"end": "2018-05-05",
+			"metadata": {
+				"links": [
+					{
+						"url": "https://linuxwochen.at/",
+						"title": "Website"
+					},
+					{
+						"url": "https://cfp.linuxwochen.at/img/LWW_FH_Technikum.png",
+						"title": "Map",
+						"type": "image/png"
 					}
 				]
 			}


### PR DESCRIPTION
Linuxwochen Wien (a 3-day FLOSS event in Vienna with 3 tracks plus workshops and Python side events) starts tomorrow (or actually today); if that could make it in it'd be great, but obviously I am very very late, and I'll perfectly understand rejection of this PR.

CI checked and did not complain. The event has no square logo I could easily find.