### PR TITLE
Added 35C3

### DIFF
--- a/app/src/main/res/raw/menu.json
+++ b/app/src/main/res/raw/menu.json
@@ -1,6 +1,25 @@
 {
-	"version": 2018102402,
+	"version": 2018121800,
 	"schedules": [
+		{
+			"title": "35th Chaos Communication Congress",
+			"metadata": {
+				"links": [
+					{
+						"url": "https://events.ccc.de/congress/2018/wiki/index.php/Main_Page",
+						"title": "Wiki"
+					},
+					{
+						"title": "Weblog",
+						"url": "https://events.ccc.de/"
+					}
+				]
+			},
+			"url": "https://fahrplan.events.ccc.de/congress/2018/Fahrplan/schedule.xml",
+			"start": "2018-12-27",
+			"end": "2018-12-30",
+			"version": 2018121800
+		},
 		{
 			"version": 2017041700,
 			"url": "https://luga-ev.github.io/frab-extras/2017/de/lit2017/public/schedule.xml",


### PR DESCRIPTION
Added 35C3 to the event list. There is a (temporary, hopefully) error with `ci/menu-ci.py`, due to the fact that the wiki for the 2018 event is not public yet and requires authorisation:

 EDIT: now the wiki link is accessible, I made an empty commit to re-trigger the CI

```
$ ./ci/menu-ci.py 
Base ref: master
New: 35th Chaos Communication Congress
Fetching https://fahrplan.events.ccc.de/congress/2018/Fahrplan/schedule.xml
Fetching https://events.ccc.de/congress/2018/wiki/index.php/Main_Page
Fetching https://events.ccc.de/
Unchanged: Augsburger Linux-Infotag 2017 (fixed)
Unchanged: LibrePlanet 2017
Unchanged: Opensouthcode 2017
Unchanged: TUEBIX 2017
Unchanged: SHA2017
Unchanged: GUADEC 2018
Unchanged: DebConf17
Unchanged: FrOSCon 2017
Unchanged: PyConFR 2017
Unchanged: LinuxDays 2017
Unchanged: Vintage Computing Festival Berlin 2017
Unchanged: PrivacyWeek 2017
Unchanged: FSCONS 2017
Unchanged: Capitole du Libre 2017
Unchanged: Forum PHP 2017
Unchanged: JRES 2017
Unchanged: LinuxDay.at 2017
Unchanged: NLUUG Autumn 2017
Unchanged: Botconf 2017
Unchanged: 34th Chaos Communication Congress
Unchanged: FOSDEM 2018
Unchanged: linux.conf.au 2018
Unchanged: JDLL 2018
Unchanged: FOSSASIA 2018
Unchanged: LibrePlanet 2018
Unchanged: PHP Tour Montpellier 2018
Unchanged: NLUUG Spring 2018
Unchanged: T&#xFC;bix 2018
Unchanged: Rencontres Mondiales du Logiciel Libre 2018
Unchanged: PromCon 2018
Unchanged: Forum PHP 2018
Unchanged: Capitole du Libre 2018
Unchanged: PrivacyWeek 2018
Unchanged: RML 12
There were some problems with this file!

Wiki link for 35th Chaos Communication Congress appears broken: 401 Unauthorized
```