### PR TITLE
Enforce python 3.6 early in CI tests

### DIFF
--- a/ci/menu-ci.py
+++ b/ci/menu-ci.py
@@ -14,12 +14,21 @@ Sadly I'll need to duplicate some things from Giggity's Java code I guess...
 
 
 import json
-import jsonschema
 import os
-import PIL.Image
 import re
 import subprocess
+import sys
+
+# version check. This script requires at least python 3.6
+# Currently the only 3.6 feature that is used in this script is `encoding` in
+# Popen.
+if sys.version_info[:2] < (3, 6):
+    raise RuntimeError("at least python 3.6 is required")
+
+import jsonschema
+import PIL.Image
 import urllib3
+
 
 class MenuError(Exception):
 	pass


### PR DESCRIPTION
The script `ci/menu-ci.py` requires features only available in Python 3.6, which is not available by default on every distributions (e.g. in Debian it's part of `testing`).

This could be changed to allow lower version numbers, but until then it would be good to break early so the user won't have to look up what's wrong from the exception, and figure out themselves that the Python version is not recent enough.

I am not changing the hashbang to `#!/usr/bin/env python3.6` because that would also stop from using newer versions