### PR TITLE
Add LIT 2019

### DIFF
--- a/menu/lit_2019.json
+++ b/menu/lit_2019.json
@@ -1,0 +1,16 @@
+{
+	"version": 2019022500,
+	"url": "https://frab.luga.de/de/LIT2019/public/schedule.xml",
+	"title": "Augsburger Linux-Infotag 2019",
+	"start": "2019-04-06",
+	"end": "2019-04-06",
+	"metadata": {
+		"icon": "https://luga-ev.github.io/frab-extras/Tux2.png",
+		"links": [
+			{
+				"url": "https://www.luga.de/Aktionen/LIT-2019/",
+				"title": "Website"
+			}
+		]
+	}
+}


### PR DESCRIPTION
The LIT was included in Giggity for the 2017 installment. In 2018, we unfortunately were too late in submitting the pull request. We hope that it'll work again for 2019. :-)

The linked schedule is not yet accessible, but will be soon.

Thank you for your efforts in maintaining Giggity. :-)