### PR TITLE
Add Installfest 2019 to menu

### DIFF
--- a/menu/installfest_2019.json
+++ b/menu/installfest_2019.json
@@ -1,0 +1,20 @@
+{
+	"version": 2019022701,
+	"url": "https://installfest.cz/if19/schedule.xml",
+	"title": "Installfest 2019",
+	"start": "2019-03-02",
+	"end": "2019-03-03",
+    "metadata": {
+            "icon": "https://installfest.cz/if19/images/logo-tux.png",
+			"links": [
+				{
+					"url": "https://installfest.cz",
+					"title": "Web Installfestu"
+				},
+				{
+					"url": "https://installfest.cz/if19/info",
+					"title": "Info o konferenci"
+				}
+			]
+		}
+}


### PR DESCRIPTION
I know we've sent PR at the last moment, but be so kind and merge json for Installfest. It's Czech conference about Linux and open-source technologies which takes place on March 2–3. Thank you (and thank you for giggity, it's great app). 
