### PR TITLE
Add IETF104 to events

### DIFF
--- a/menu/ietf104.json
+++ b/menu/ietf104.json
@@ -1,0 +1,19 @@
+{
+	"version": 2016080500,
+	"title": "IETF 104 Prague",
+	"url": "https://datatracker.ietf.org/meeting/104/agenda.ics",
+	"start": "2019-03-23",
+	"end": "2019-03-29",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://www.ietf.org/how/meetings/104/",
+				"title": "Website"
+			},
+			{
+				"url": "https://datatracker.ietf.org/meeting/104/floor-plan",
+				"title": "Floor plans"
+			}
+		]
+	}
+}


### PR DESCRIPTION
The conference happens in Prague and starts this weekend.

The schedule suffers a bit from #96, but is well usable within. (Don't get distraught by the first view – the event starts at Saturday with a hackathon block entry, the later days are the ones where I need giggity to keep track of where to be when).