### PR TITLE
Add the Tübix 2019

### DIFF
--- a/menu/tuebix_2019.json
+++ b/menu/tuebix_2019.json
@@ -1,0 +1,20 @@
+{
+	"version": 2019053100,
+	"url": "https://www.tuebix.org/2019/giggity.xml",
+	"title": "Tübix 2019",
+	"start": "2019-07-06",
+	"end": "2019-07-06",
+	"metadata": {
+		"icon": "https://www.tuebix.org/2017/giggity.icon.png",
+		"links": [
+			{
+				"url": "https://www.tuebix.org/",
+				"title": "Website"
+			},
+			{
+				"url": "https://www.tuebix.org/anfahrt/",
+				"title": "Anfahrt"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Things done:
- [x] Read README.md
- [x] Scanned the QR code with Giggity (everything worked, including the icon)
- [x] Tested the change with `./ci/menu-ci.py`

Results:
```bash
$ ./ci/menu-ci.py 
Base ref: HEAD
Unchanged: FOSSASIA 2018
Unchanged: JDLL 2018
Unchanged: LibrePlanet 2018
Unchanged: NLUUG Spring 2018
Unchanged: PHP Tour Montpellier 2018
Unchanged: T&#xFC;bix 2018
Unchanged: GUADEC 2018
Unchanged: Rencontres Mondiales du Logiciel Libre 2018
Unchanged: PromCon 2018
Unchanged: PrivacyWeek 2018
Unchanged: Forum PHP 2018
Unchanged: Capitole du Libre 2018
Unchanged: RML 12
Unchanged: 35c3 - main rooms only
Unchanged: 35c3 - new and merged
Unchanged: linux.conf.au 2019
Unchanged: FOSDEM 2019
Unchanged: CfgMgmtCamp 2019 Ghent
Unchanged: Installfest 2019
Unchanged: LibrePlanet 2019
Unchanged: IETF 104 Prague
Unchanged: Augsburger Linux-Infotag 2019
Unchanged: Journées du Logiciel Libre 2019
Unchanged: RML 13
Unchanged: Opensouthcode 2019
New: Tübix 2019
Fetching https://www.tuebix.org/2019/giggity.xml
Fetching https://www.tuebix.org/2017/giggity.icon.png
Fetching https://www.tuebix.org/
Fetching https://www.tuebix.org/anfahrt/

$ echo $?
0
```
<table>
<td>
<img alt="tuebix-home" src="https://user-images.githubusercontent.com/7537109/58722197-209edc00-83d7-11e9-9a10-3e7fa4076a01.jpeg">
</td>
<td>
<img alt="tuebix-schedule" src="https://user-images.githubusercontent.com/7537109/58722206-25fc2680-83d7-11e9-81e3-39b742889623.jpeg">
</td>
</table>

(Previous PR: #106)