### PR TITLE
Add PyCon AU 2019 to menu

### DIFF
--- a/menu/pyconau_2019.json
+++ b/menu/pyconau_2019.json
@@ -1,0 +1,16 @@
+{
+	"version": 2019080200,
+	"url": "https://2019.pycon-au.org/schedule/conference.ics",
+	"title": "PyCon AU 2019",
+	"start": "2019-08-02",
+	"end": "2019-08-04",
+	"metadata": {
+		"icon": "https://2019.pycon-au.org/static/img/favicon.png",
+		"links": [
+			{
+				"url": "https://2019.pycon-au.org/",
+				"title": "Website"
+			}
+		]
+	}
+}

--- a/menu/pyconau_2019.json
+++ b/menu/pyconau_2019.json
@@ -10,6 +10,11 @@
 			{
 				"url": "https://2019.pycon-au.org/",
 				"title": "Website"
+			},
+			{
+				"url": "https://2019.pycon-au.org/static/img/venuemap.png",
+				"title": "Map",
+				"type": "image/png"
 			}
 		]
 	}


### PR DESCRIPTION
PyCon AU has started!

For those who don't want to wait until this merged, here's a QR code:

![pyconau_2019](https://user-images.githubusercontent.com/128854/62336274-ef47a700-b512-11e9-94cd-e478f870ff49.png)