### PR TITLE
Add Bibliothekartag 2020 to menu

### DIFF
--- a/menu/bibtag20.json
+++ b/menu/bibtag20.json
@@ -1,0 +1,25 @@
+{
+	"version": 2020021001,
+	"url": "https://cloud.bib.uni-mannheim.de/index.php/s/AwMc2ao8C2fX8rJ/download",
+	"title": "Bibliothekartag 2020",
+	"start": "2020-05-26",
+	"end": "2020-05-29",
+	"metadata": {
+		"icon": "https://pbs.twimg.com/profile_images/1138817129342521344/3jcmODs__200x200.png",
+		"links": [
+			{
+				"url": "https://bibliothekartag2020.de/",
+				"title": "Webseite"
+			},
+			{
+				"url": "https://bibliothekartag2020.de/der-kongress/informationen-von-a-z/",
+				"title": "Informationen von A-Z"
+			},
+			{
+				"url": "https://bibliothekartag2020.de/wp-content/uploads/2019/04/Behindertengerechte-Einrichtungen-HCC.jpg",
+				"title": "Karte HCC",
+				"type": "image/jpeg"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Add Bibliothekartag 2020 to menu which uses a Pentabarf XML created by https://github.com/UB-Mannheim/bibtag-scheduler