### PR TITLE
Allow schedules hosted on http websites

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 	<uses-permission android:name="android.permission.VIBRATE"/>
 	<uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
-	<application android:label="@string/app_name" android:name="Giggity" android:icon="@drawable/deoxide_icon" android:allowBackup="true" android:theme="@style/Theme.Giggity.NoShadow">
+	<application android:label="@string/app_name" android:name="Giggity" android:icon="@drawable/deoxide_icon" android:allowBackup="true" android:theme="@style/Theme.Giggity.NoShadow" android:usesCleartextTraffic="true">
 		<activity android:configChanges="keyboardHidden|orientation|screenSize" android:name="ScheduleViewActivity" android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
This attribute change allows using schedules that are hosted on non-ssl enabled websites. Currently Android 9+ forbids this without an explicit permission.

Re: [stackoverflow](https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted) and [attribute documentation](https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic).