### PR TITLE
WIP: Add HOPE 2020

### DIFF
--- a/menu/hope_2020.json
+++ b/menu/hope_2020.json
@@ -1,0 +1,16 @@
+{
+	"version": 2020061701,
+	"url": "https://scheduler.hope.net/hope2020/schedule/export/schedule.xml",
+	"title": "HOPE 2020",
+	"start": "2020-07-25",
+	"end": "2020-08-02",
+	"metadata": {
+		"icon": "https://pbs.twimg.com/profile_images/1194682670346907650/Uu73PLJc_200x200.jpg",
+		"links": [
+			{
+				"url": "https://www.hope.net/",
+				"title": "Website"
+			}
+		]
+	}
+}


### PR DESCRIPTION
HOLD: URL is temporary, final URL should be available at the end of the week.

Tested, works even on my Android 4 tablet, for once.