### PR TITLE
Add FrOSCon 2020

### DIFF
--- a/menu/froscon_2020.json
+++ b/menu/froscon_2020.json
@@ -1,25 +1,15 @@
 {
-    "version": 2019071700,
-    "url": "https://programm.froscon.de/2019/schedule.xml",
-    "title": "FrOSCon 2019",
-    "start": "2019-08-10",
-    "end": "2019-08-11",
+    "version": 2020081800,
+    "url": "https://programm.froscon.de/2020/schedule.xml",
+    "title": "FrOSCon 2020",
+    "start": "2020-08-22",
+    "end": "2020-08-23",
     "metadata": {
         "icon": "https://www.froscon.de/fileadmin/images/logos/frog_button.png",
         "links": [
             {
                 "url": "https://www.froscon.org/",
                 "title": "Website"
-            },
-            {
-                "url": "https://programm.froscon.de/maps/map1.png",
-                "title": "Map1",
-                "type": "image/png"
-            },
-            {
-                "url": "https://programm.froscon.de/maps/map2.png",
-                "title": "Map2",
-                "type": "image/png"
             },
             {
                 "url": "https://www.froscon.de/en/news/",


### PR DESCRIPTION
Just noticed FrOSCon is this week-end :)

Removed the map links, hopefully we can add them back next year.