### PR TITLE
Add Kielux 2021 / LPD21.2 (online events)

### DIFF
--- a/menu/kielux_2021.json
+++ b/menu/kielux_2021.json
@@ -1,0 +1,25 @@
+{
+	"version": 202082900,
+	"url": "https://kielux.de/content/calendars/KOLT20.ics",
+	"title": "19. Kieler Open Source und Linux Tage Online", 
+	"start": "2021-09-17",
+	"end": "2021-09-18",
+	"refresh_interval": 1800,
+	"metadata": {
+		"icon": "https://kielux.de/static/images/kielux_tux_square.png",
+		"links": [
+			{
+				"url": "https://kielux.de",
+				"title": "Website"
+			},
+			{
+				"url": "https://kielux.de/programm/KOLT21",
+				"title": "Schedule and workshop registration"
+			},
+			{
+				"url": "https://kielux.de/archiv",
+				"title": "News"
+			}
+		]
+	}
+}

--- a/menu/kielux_2021.json
+++ b/menu/kielux_2021.json
@@ -1,5 +1,5 @@
 {
-	"version": 202082900,
+	"version": 202182900,
 	"url": "https://kielux.de/content/calendars/KOLT20.ics",
 	"title": "19. Kieler Open Source und Linux Tage Online", 
 	"start": "2021-09-17",

--- a/menu/kielux_2021.json
+++ b/menu/kielux_2021.json
@@ -1,6 +1,6 @@
 {
 	"version": 202182900,
-	"url": "https://kielux.de/content/calendars/KOLT20.ics",
+	"url": "https://kielux.de/content/calendars/KOLT21.ics",
 	"title": "19. Kieler Open Source und Linux Tage Online", 
 	"start": "2021-09-17",
 	"end": "2021-09-18",

--- a/menu/kielux_2021.json
+++ b/menu/kielux_2021.json
@@ -1,5 +1,5 @@
 {
-	"version": 202182900,
+	"version": 2021082900,
 	"url": "https://kielux.de/content/calendars/KOLT21.ics",
 	"title": "19. Kieler Open Source und Linux Tage Online", 
 	"start": "2021-09-17",

--- a/menu/kielux_LPD_2021.json
+++ b/menu/kielux_LPD_2021.json
@@ -1,0 +1,25 @@
+{
+	"version": 2021082900,
+	"url": "https://kielux.de/content/calendars/LPD21.ics",
+	"title": "Kieler Linux Presentation Day 2021.2", 
+	"start": "2021-09-16",
+	"end": "2021-09-16",
+	"refresh_interval": 1800,
+	"metadata": {
+		"icon": "https://kielux.de/static/images/kielux_tux_square.png",
+		"links": [
+			{
+				"url": "https://kielux.de",
+				"title": "Website"
+			},
+			{
+				"url": "https://kielux.de/programm/LPD21",
+				"title": "Schedule"
+			},
+			{
+				"url": "https://kielux.de/archiv",
+				"title": "News"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Hi @Wilm0r !

Kielux will start soon! This year's online event features 22 talks, 10 workshops and a Software Freedom Breakfast.

I've added our ics file links to the repository.

Greetings from Kiel!

