### PR TITLE
Add JRES 2022

### DIFF
--- a/menu/jres_2022.json
+++ b/menu/jres_2022.json
@@ -1,0 +1,20 @@
+{
+	"version": 2022030200,
+	"url": "https://conf-ng.jres.org/2021/rest/planning.ics",
+	"title": "JRES 2022",
+	"start": "2022-05-17",
+	"end": "2022-05-20",
+	"timezone": "Europe/Paris",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://www.jres.org/",
+				"title": "Site Web"
+			},
+			{
+				"url": "https://www.jres.org/inscriptions/",
+				"title": "Inscription"
+			}
+		]
+	}
+}


### PR DESCRIPTION
We don't need the `id` field anymore for ICS, right?