### PR TITLE
Check for null timezone when loading schedule.

### DIFF
--- a/app/src/main/java/net/gaast/giggity/ScheduleUI.java
+++ b/app/src/main/java/net/gaast/giggity/ScheduleUI.java
@@ -56,7 +56,7 @@ public class ScheduleUI extends Schedule {
 		Db.DbSchedule ds = ctx.getDb().getSchedule(url);
 		if (ds != null) {
 			String tz = ds.getTimezone();
-			if (!tz.isEmpty()) {
+			if (tz != null && !tz.isEmpty()) {
 				ret.setInTZ(ZoneId.of(tz));
 			}
 		}


### PR DESCRIPTION
When refreshing a schedule for a custom URL, `tz` is null and and a `NullPointerException` is thrown.