### PR TITLE
Add Bibliothekskongress 2022

### DIFF
--- a/menu/bibtag22.json
+++ b/menu/bibtag22.json
@@ -1,0 +1,25 @@
+{
+	"version": 2022050101,
+	"url": "https://cloud.bib.uni-mannheim.de/s/QNzesdFeDg6tJ5j/download/bibtag22.xml",
+	"title": "Bibliothekskongress 2022",
+	"start": "2022-05-31",
+	"end": "2022-06-02",
+	"timezone": "Europe/Berlin",
+	"metadata": {
+		"icon": "https://pbs.twimg.com/profile_images/1415287443021041665/FTLcB15h_400x400.png",
+		"links": [
+			{
+				"url": "https://www.bid-kongress-leipzig.de/",
+				"title": "Webseite"
+			},
+			{
+				"url": "https://www.bid-kongress-leipzig.de/index.php?id=24",
+				"title": "Informationen von A-Z"
+			},
+			{
+				"url": "https://www.ccl-leipzig.de/de/location/gelaendeueberblick/",
+				"title": "Geländeübersicht Congress Center"
+			}
+		]
+	}
+}

--- a/menu/bibtag22.json
+++ b/menu/bibtag22.json
@@ -6,7 +6,6 @@
 	"end": "2022-06-02",
 	"timezone": "Europe/Berlin",
 	"metadata": {
-		"icon": "https://pbs.twimg.com/profile_images/1415287443021041665/FTLcB15h_400x400.png",
 		"links": [
 			{
 				"url": "https://www.bid-kongress-leipzig.de/",


### PR DESCRIPTION
I am having some troubles to add the json file from another location directly, but hope this will work fine from the menu here. The pentabarf file works fine. However, updating a schedule where the pentabarf file is added directly seems not yet to work in the current version, because the fix https://github.com/Wilm0r/giggity/commit/9c404210fa9524c7caab3a209fb21a3c26b21311 is not yet part of the released version.