### PR TITLE
Update source of State of the Map 2022 schedule: adds missing academic talks

### DIFF
--- a/menu/sotm_2022.json
+++ b/menu/sotm_2022.json
@@ -1,5 +1,5 @@
 {
-        "version": 2022060701,
+        "version": 2022080901,
         "url": "https://sotm.osmz.ru/2022.xml",
         "title": "State of the Map 2022",
         "start": "2022-08-19",

--- a/menu/sotm_2022.json
+++ b/menu/sotm_2022.json
@@ -1,6 +1,6 @@
 {
         "version": 2022060701,
-        "url": "https://pretalx.com/sotm2022/schedule/export/schedule.xml",
+        "url": "https://sotm.osmz.ru/2022.xml",
         "title": "State of the Map 2022",
         "start": "2022-08-19",
         "end": "2022-08-21",


### PR DESCRIPTION
The schedule on https://pretalx.com/sotm2022/ is missing the academic track talks (on Sunday in Auditorium B, see https://2022.stateofthemap.org/programme/#general_Sunday), because the academic talks are managed in a separate pretalx instance (https://pretalx.com/state-of-the-map-2022-academic-track/ vs. https://pretalx.com/sotm2022/). For this reason, we maintain a merged schedule xml during the conference days available at https://sotm.osmz.ru/2022.xml