### PR TITLE
Add OAT22 to the menu

### DIFF
--- a/menu/oat22.json
+++ b/menu/oat22.json
@@ -1,0 +1,17 @@
+	{
+		"version": 2022082401,
+		"url": "https://cloud.bib.uni-mannheim.de/s/f35r5JMRZywZBoa/download/oat22.xml",
+		"title": "Open-Access-Tage 2022",
+		"start": "2022-09-19",
+		"end": "2022-09-21",
+		"timezone": "Europe/Berlin",
+		"metadata": {
+			"icon": "https://cloud.bib.uni-mannheim.de/s/aCFfyztnYjJMC5y/download/oat22-icon.png",
+			"links": [
+				{
+					"url": "https://open-access-tage.de/open-access-tage-2022-bern",
+					"title": "Website"
+				}
+			]
+		}
+	}


### PR DESCRIPTION
I created a skeleton of the schedule (manually) as an XML file and updated it with the abstracts from the website. The icon is from twitter, but I needed to add an alpha layer (hope this works now).