### PR TITLE
Add Kielux / Kielux Linux Presentation Day 2022

### DIFF
--- a/menu/Kielux_LPD_2022.json
+++ b/menu/Kielux_LPD_2022.json
@@ -1,0 +1,29 @@
+
+{
+  "version": 20220827,
+	"title": "Kielux Linux Presentation Day",
+	"url": "https://kielux.de/content/calendars/LPD22.ics",
+	"start": "2022-09-15",
+	"end": "2022-09-15",
+  "timezone": "Europe/Berlin",
+  "refresh_interval": 1800,
+	"metadata": {
+    "icon": "https://kielux.de/static/images/kielux_tux_square.png",
+		"links": [
+			{
+				"url": "https://kielux.de",
+				"title": "Website"
+			},
+      {
+				"url": "https://kielux.de/programm/LPD22",
+				"title": "Schedule"
+			},
+		],
+		"rooms": [
+			{
+				"name": "R012",
+				"latlon": [54.33497, 10.11928]
+			},
+		]
+	}
+}

--- a/menu/kielux_2022.json
+++ b/menu/kielux_2022.json
@@ -1,20 +1,19 @@
-
 {
-  "version": 20220827,
+	"version": 20220827,
 	"title": "20. Kieler Open Source und Linux Tage",
 	"url": "https://kielux.de/content/calendars/KOLT22.ics",
 	"start": "2022-09-16",
 	"end": "2022-09-17",
-  "timezone": "Europe/Berlin",
-  "refresh_interval": 1800,
+	"timezone": "Europe/Berlin",
+	"refresh_interval": 1800,
 	"metadata": {
-    "icon": "https://kielux.de/static/images/kielux_tux_square.png",
+		"icon": "https://kielux.de/static/images/kielux_tux_square.png",
 		"links": [
 			{
 				"url": "https://kielux.de",
 				"title": "Website"
 			},
-      {
+			{
 				"url": "https://kielux.de/programm/KOLT22",
 				"title": "Schedule and workshop registration"
 			},
@@ -25,7 +24,7 @@
 			{
 				"title": "Exhibition",
 				"url": "https://kielux.de/aussteller"
-			},
+			}
 		],
 		"rooms": [
 			{
@@ -39,7 +38,7 @@
 			{
 				"name": "R114",
 				"latlon": [54.33510, 10.11944]
-			},
+			}
 		]
 	}
 }

--- a/menu/kielux_2022.json
+++ b/menu/kielux_2022.json
@@ -1,0 +1,45 @@
+
+{
+  "version": 20220827,
+	"title": "20. Kieler Open Source und Linux Tage",
+	"url": "https://kielux.de/content/calendars/KOLT22.ics",
+	"start": "2022-09-16",
+	"end": "2022-09-17",
+  "timezone": "Europe/Berlin",
+  "refresh_interval": 1800,
+	"metadata": {
+    "icon": "https://kielux.de/static/images/kielux_tux_square.png",
+		"links": [
+			{
+				"url": "https://kielux.de",
+				"title": "Website"
+			},
+      {
+				"url": "https://kielux.de/programm/KOLT22",
+				"title": "Schedule and workshop registration"
+			},
+			{
+				"title": "Entertainment",
+				"url": "https://kielux.de/aktionen"
+			},
+			{
+				"title": "Exhibition",
+				"url": "https://kielux.de/aussteller"
+			},
+		],
+		"rooms": [
+			{
+				"name": "R012",
+				"latlon": [54.33497, 10.11928]
+			},
+			{
+				"name": "R007",
+				"latlon": [54.33547, 10.11951]
+			},
+			{
+				"name": "R114",
+				"latlon": [54.33510, 10.11944]
+			},
+		]
+	}
+}

--- a/menu/kielux_2022.json
+++ b/menu/kielux_2022.json
@@ -1,5 +1,5 @@
 {
-	"version": 20220827,
+	"version": 2022082701,
 	"title": "20. Kieler Open Source und Linux Tage",
 	"url": "https://kielux.de/content/calendars/KOLT22.ics",
 	"start": "2022-09-16",

--- a/menu/kielux_LPD_2022.json
+++ b/menu/kielux_LPD_2022.json
@@ -1,5 +1,5 @@
 {
-	"version": 20220827,
+	"version": 2022082701,
 	"title": "Kielux Linux Presentation Day",
 	"url": "https://kielux.de/content/calendars/LPD22.ics",
 	"start": "2022-09-15",

--- a/menu/kielux_LPD_2022.json
+++ b/menu/kielux_LPD_2022.json
@@ -1,29 +1,28 @@
-
 {
-  "version": 20220827,
+	"version": 20220827,
 	"title": "Kielux Linux Presentation Day",
 	"url": "https://kielux.de/content/calendars/LPD22.ics",
 	"start": "2022-09-15",
 	"end": "2022-09-15",
-  "timezone": "Europe/Berlin",
-  "refresh_interval": 1800,
+	"timezone": "Europe/Berlin",
+	"refresh_interval": 1800,
 	"metadata": {
-    "icon": "https://kielux.de/static/images/kielux_tux_square.png",
+		"icon": "https://kielux.de/static/images/kielux_tux_square.png",
 		"links": [
 			{
 				"url": "https://kielux.de",
 				"title": "Website"
 			},
-      {
+			{
 				"url": "https://kielux.de/programm/LPD22",
 				"title": "Schedule"
-			},
+			}
 		],
 		"rooms": [
 			{
 				"name": "R012",
 				"latlon": [54.33497, 10.11928]
-			},
+			}
 		]
 	}
 }


### PR DESCRIPTION
Hi! This patch adds our Kielux Linux conference and the preceding Kielux Linux Presentation Day to Giggity.

The events are from September 15 to 17 2022.