### PR TITLE
Link to xml file of frab export

### DIFF
--- a/menu/lit_2023.json
+++ b/menu/lit_2023.json
@@ -1,6 +1,6 @@
 {
-	"version": 2023042501,
-	"url": "https://pretalx.luga.de/lit-2023/schedule/export/schedule.json",
+	"version": 2023042600,
+	"url": "https://pretalx.luga.de/lit-2023/schedule/export/schedule.xml",
 	"title": "Augsburger Linux-Infotag 2023",
 	"start": "2023-04-29",
 	"end": "2023-04-29",


### PR DESCRIPTION
It seems that the link should go to the xml version, not the json version, This PR fixes the mistake.