### PR TITLE
Add BornHack 2023

### DIFF
--- a/menu/bornhack_2023.json
+++ b/menu/bornhack_2023.json
@@ -1,0 +1,28 @@
+{
+	"version": 2023051918,
+	"url": "https://bornhack.dk/bornhack-2023/program/frab.xml",
+	"title": "BornHack 2023",
+	"start": "2023-08-02",
+	"end": "2023-08-09",
+	"timezone": "Europe/Copenhagen",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://bornhack.dk/bornhack-2023/",
+				"title": "Website"
+			},
+			{
+			"url": "https://bornhack.dk/bornhack-2023/info/",
+				"title": "Info"
+			},
+			{
+				"url": "https://bornhack.dk/news/",
+				"title": "News"
+			},
+			{
+				"url": "https://bornhack.dk/bornhack-2023/facilities/",
+				"title": "Facilities"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Add [BornHack 2023](https://bornhack.dk/bornhack-2023/). The [program](https://bornhack.dk/bornhack-2023/program/events/) times is not published yet, so the frab file is not filled out with the schedule.