### PR TITLE
Switch FOSSY 2023 to use ICS

### DIFF
--- a/menu/fossy_2023.json
+++ b/menu/fossy_2023.json
@@ -1,6 +1,6 @@
 {
-	"version": 2023062201,
-	"url": "https://2023.fossy.us/schedule/conference.json",
+	"version": 2023070401,
+	"url": "https://2023.fossy.us/schedule/conference.ics",
 	"title": "FOSSY 2023",
 	"start": "2023-07-13",
 	"end": "2023-07-16",


### PR DESCRIPTION
FOSSY hasn't published a schedule in XML format. The JSON format used by the FOSSY schedule isn't supported by giggity. Switch to using the ICS version of the schedule instead.