### PR TITLE
FOSSY 2023: Use schedule in XML converted from the JSON version

### DIFF
--- a/menu/fossy_2023.json
+++ b/menu/fossy_2023.json
@@ -1,7 +1,7 @@
 {
 	"version": 2023070501,
 	"url": "https://edwardbetts.com/fossy_2023/schedule.xml",
-	"title": "FOSSY 2023",
+	"title": "FOSSY 2023 (use this one!)",
 	"start": "2023-07-13",
 	"end": "2023-07-16",
 	"timezone": "America/Los_Angeles",

--- a/menu/fossy_2023.json
+++ b/menu/fossy_2023.json
@@ -1,6 +1,6 @@
 {
-	"version": 2023070401,
-	"url": "https://2023.fossy.us/schedule/conference.ics",
+	"version": 2023070501,
+	"url": "https://edwardbetts.com/fossy_2023/schedule.xml",
 	"title": "FOSSY 2023",
 	"start": "2023-07-13",
 	"end": "2023-07-16",


### PR DESCRIPTION
Reads a version of the schedule in XML that has been generated from the JSON version of the schedule.

The XML version is being regenerated regularly.

This gives more detail that the ICS version.