### PR TITLE
Add SSTIC 2024

### DIFF
--- a/menu/sstic_2024.json
+++ b/menu/sstic_2024.json
@@ -1,0 +1,16 @@
+{
+	"version": 2024053100,
+	"url": "https://www.sstic.org/2024/programme.ics",
+	"title": "SSTIC 2024",
+	"start": "2024-06-05",
+	"end": "2024-06-07",
+	"timezone": "Europe/Paris",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://www.sstic.org/2024/news/",
+				"title": "Site web"
+			}
+		]
+	}
+}


### PR DESCRIPTION
I get an error "Schedule seems empty" on my old Android 4 tablet… Does it work on recent Giggity?