### PR TITLE
Add OpenSouthCode 2024

### DIFF
--- a/menu/opensouthcode_2024.json
+++ b/menu/opensouthcode_2024.json
@@ -1,0 +1,17 @@
+{
+	"version": 2024051901,
+	"url": "https://www.opensouthcode.org/conferences/opensouthcode2024/schedule.xml",
+	"title": "OpenSouthCode 2024",
+	"start": "2024-06-21",
+	"end": "2024-06-22",
+	"timezone": "Europe/Madrid",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://www.opensouthcode.org/conferences/opensouthcode2024",
+				"title": "Website"
+			}
+		],
+		"icon": "https://www.opensouthcode.org/logo1.png"
+	}
+}


### PR DESCRIPTION
Add Opensouthcode 2024, June 21 and 22 in Málaga (Spain)