### PR TITLE
Better FOSS4G Europe 2024 schedule

### DIFF
--- a/menu/foss4g_europe_2024.json
+++ b/menu/foss4g_europe_2024.json
@@ -32,7 +32,7 @@
 			},
 			{
 				"name": "Room .*|Destination.*|GEOCAT.*|LAStools.*|QField.*|Vanemuise 46",
-        "show_name": "Vanemuise 46",
+				"show_name": "Vanemuise 46",
 				"latlon": [58.37347, 26.71616]
 			},
 			{

--- a/menu/foss4g_europe_2024.json
+++ b/menu/foss4g_europe_2024.json
@@ -32,6 +32,7 @@
 			},
 			{
 				"name": "Room .*|Destination.*|GEOCAT.*|LAStools.*|QField.*|Vanemuise 46",
+        "show_name": "Vanemuise 46",
 				"latlon": [58.37347, 26.71616]
 			},
 			{

--- a/menu/foss4g_europe_2024.json
+++ b/menu/foss4g_europe_2024.json
@@ -1,15 +1,58 @@
 {
-	"version": 2024040400,
-	"url": "https://talks.osgeo.org/foss4g-europe-2024/schedule/export/schedule.xml",
+	"version": 2024061900,
+	"url": "https://sotm.osmz.ru/tartu2024.xml",
 	"title": "FOSS4G Europe 2024",
-	"start": "2024-07-03",
-	"end": "2024-07-05",
+	"start": "2024-07-01",
+	"end": "2024-07-07",
 	"timezone": "Europe/Tallinn",
+	"refresh_interval": 7200,
 	"metadata": {
 		"links": [
 			{
 				"url": "https://2024.europe.foss4g.org/",
 				"title": "Website"
+			},
+			{
+				"url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2024/BirdsOfAFeather",
+				"title": "Birds of a Feather"
+			},
+			{
+				"url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2024/CommunitySprint",
+				"title": "Community Sprint"
+			},
+			{
+				"url": "https://2024.europe.foss4g.org/sponsors/",
+				"title": "Sponsors"
+			}
+		],
+		"rooms": [
+			{
+				"name": "Raekoja plats",
+				"latlon": [58.38009, 26.72224]
+			},
+			{
+				"name": "Room .*|Destination.*|GEOCAT.*|LAStools.*|QField.*|Vanemuise 46",
+				"latlon": [58.37347, 26.71616]
+			},
+			{
+				"name": "Mart Reiniku",
+				"latlon": [58.37290, 26.71549]
+			},
+			{
+				"name": "Omicum",
+				"latlon": [58.37290, 26.71766]
+			},
+			{
+				"name": "Salong",
+				"latlon": [58.37628, 26.72151]
+			},
+			{
+				"name": "Aparaaditehas",
+				"latlon": [58.37046, 26.71617]
+			},
+			{
+				"name": "Lodjakoda",
+				"latlon": [58.39122, 26.71361]
 			}
 		]
 	}

--- a/menu/foss4g_europe_2024.json
+++ b/menu/foss4g_europe_2024.json
@@ -1,59 +1,15 @@
 {
-	"version": 2024061900,
-	"url": "https://sotm.osmz.ru/tartu2024.xml",
+	"version": 2024040400,
+	"url": "https://talks.osgeo.org/foss4g-europe-2024/schedule/export/schedule.xml",
 	"title": "FOSS4G Europe 2024",
-	"start": "2024-07-01",
-	"end": "2024-07-07",
+	"start": "2024-07-03",
+	"end": "2024-07-05",
 	"timezone": "Europe/Tallinn",
-	"refresh_interval": 7200,
 	"metadata": {
 		"links": [
 			{
 				"url": "https://2024.europe.foss4g.org/",
 				"title": "Website"
-			},
-			{
-				"url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2024/BirdsOfAFeather",
-				"title": "Birds of a Feather"
-			},
-			{
-				"url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2024/CommunitySprint",
-				"title": "Community Sprint"
-			},
-			{
-				"url": "https://2024.europe.foss4g.org/sponsors/",
-				"title": "Sponsors"
-			}
-		],
-		"rooms": [
-			{
-				"name": "Raekoja plats",
-				"latlon": [58.38009, 26.72224]
-			},
-			{
-				"name": "Room .*|Destination.*|GEOCAT.*|LAStools.*|QField.*|Vanemuise 46",
-				"show_name": "Vanemuise 46",
-				"latlon": [58.37347, 26.71616]
-			},
-			{
-				"name": "Mart Reiniku",
-				"latlon": [58.37290, 26.71549]
-			},
-			{
-				"name": "Omicum",
-				"latlon": [58.37290, 26.71766]
-			},
-			{
-				"name": "Salong",
-				"latlon": [58.37628, 26.72151]
-			},
-			{
-				"name": "Aparaaditehas",
-				"latlon": [58.37046, 26.71617]
-			},
-			{
-				"name": "Lodjakoda",
-				"latlon": [58.39122, 26.71361]
 			}
 		]
 	}

--- a/menu/foss4g_europe_2024_full.json
+++ b/menu/foss4g_europe_2024_full.json
@@ -1,5 +1,5 @@
 {
-	"version": 2024061900,
+	"version": 2024062500,
 	"url": "https://sotm.osmz.ru/tartu2024.xml",
 	"title": "FOSS4G Europe 2024 (extended)",
 	"start": "2024-07-01",

--- a/menu/foss4g_europe_2024_full.json
+++ b/menu/foss4g_europe_2024_full.json
@@ -1,0 +1,60 @@
+{
+	"version": 2024061900,
+	"url": "https://sotm.osmz.ru/tartu2024.xml",
+	"title": "FOSS4G Europe 2024 (extended)",
+	"start": "2024-07-01",
+	"end": "2024-07-07",
+	"timezone": "Europe/Tallinn",
+	"refresh_interval": 7200,
+	"metadata": {
+		"links": [
+			{
+				"url": "https://2024.europe.foss4g.org/",
+				"title": "Website"
+			},
+			{
+				"url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2024/BirdsOfAFeather",
+				"title": "Birds of a Feather"
+			},
+			{
+				"url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2024/CommunitySprint",
+				"title": "Community Sprint"
+			},
+			{
+				"url": "https://2024.europe.foss4g.org/sponsors/",
+				"title": "Sponsors"
+			}
+		],
+		"rooms": [
+			{
+				"name": "Raekoja plats",
+				"latlon": [58.38009, 26.72224]
+			},
+			{
+				"name": "Room .*|Destination.*|GEOCAT.*|LAStools.*|QField.*|Vanemuise 46",
+				"show_name": "Vanemuise 46",
+				"latlon": [58.37347, 26.71616]
+			},
+			{
+				"name": "Mart Reiniku",
+				"latlon": [58.37290, 26.71549]
+			},
+			{
+				"name": "Omicum",
+				"latlon": [58.37290, 26.71766]
+			},
+			{
+				"name": "Salong",
+				"latlon": [58.37628, 26.72151]
+			},
+			{
+				"name": "Aparaaditehas",
+				"latlon": [58.37046, 26.71617]
+			},
+			{
+				"name": "Lodjakoda",
+				"latlon": [58.39122, 26.71361]
+			}
+		]
+	}
+}


### PR DESCRIPTION
The current version has only the main event schedule and no speaker names. The new one, sourced [from here](https://sotm.osmz.ru/tartu2024.html), merges main event, workshops, birds of feather, all side events, and OGC Innovation Days into one.

I have also added locations for all venues.