### PR TITLE
Add OAT24 to the menu

### DIFF
--- a/menu/oat24.json
+++ b/menu/oat24.json
@@ -1,0 +1,20 @@
+{
+	"version": 2024072201,
+	"url": "https://cloud.bib.uni-mannheim.de/s/FHRYTcQpBizLAHx/download/oat24.xml",
+	"title": "Open-Access-Tage 2024",
+	"start": "2024-09-10",
+	"end": "2024-09-12",
+	"timezone": "Europe/Berlin",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://open-access-tage.de/open-access-tage-2024-koeln",
+				"title": "Website"
+			},
+			{
+				"url": "https://zenodo.org/communities/oat24/records",
+				"title": "Poster + Folien"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Add a menu entry for the Open-Access-Tage 2024.