### PR TITLE
Add Ubuntu Summit 2024

### DIFF
--- a/menu/ubuntu_summit_2024.json
+++ b/menu/ubuntu_summit_2024.json
@@ -1,0 +1,16 @@
+{
+	"version": 2024100900,
+	"url": "https://events.canonical.com/event/51/event.ics?detail=contributions",
+	"title": "Ubuntu Summit 2024",
+	"start": "2024-10-25",
+	"end": "2024-10-27",
+	"timezone": "Europe/Amsterdam",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://ubuntu.com/summit",
+				"title": "Website"
+			}
+		]
+	}
+}

--- a/tools/ggt.sh
+++ b/tools/ggt.sh
@@ -13,4 +13,4 @@ if [ -z "$url" ]; then
 	exit 1
 fi
 
-echo https://ggt.gaa.st#url="${url}"\&json="$(cat "$json" | jq -Mc "" | gzip -9 | base64 -w0 | tr +/ -_)"
+echo https://ggt.gaa.st#url="${url}"\&json="$(cat "$json" | jq -Mc "." | gzip -9 | base64 -w0 | tr +/ -_)"


### PR DESCRIPTION
Plus a small fix in `tools/ggt.sh`

One thing to note, Android (13) doesn't seem to open ggt.gaa.st by default, it says something about the link not being verified so I assume this is something you need to do somewhere. However you can manually enable this in the app settings to still test this.