### PR TITLE
38C3: set refresh_interval to 30 minutes

### DIFF
--- a/menu/38c3.json
+++ b/menu/38c3.json
@@ -20,5 +20,6 @@
 	"start": "2024-12-27",
 	"end": "2024-12-30",
 	"timezone": "Europe/Berlin",
-	"version": 2024121200
+	"refresh_interval": 1800,
+	"version": 2024121201
 }


### PR DESCRIPTION
38C3 Fahrplan changes happen frequently and often last-minute. The 30 minute value is copied from last year's 37C3, which apparently went without issues.

The server currently doesn't support `If-None-Match` properly, which is why CI will fail.

I'm proposing this as a PR anyway, so we can merge as soon as either

1) the issue is fixed server-side or
2) the admins approve this PR (in which case the CI should be ignored imho)
