### PR TITLE
FOSS4G Europe 2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /app/build
 __pycache__
+.mypy_cache/
+.python-version
+uv.lock
 
 # from https://raw.githubusercontent.com/github/gitignore/master/Android.gitignore as of 2024-07-04
 # Gradle files

--- a/menu/foss4g_europe_2025.json
+++ b/menu/foss4g_europe_2025.json
@@ -1,0 +1,68 @@
+{
+  "version": 2025042800,
+  "url": "https://sotm.osmz.ru/fe2025.xml",
+  "title": "FOSS4G Europe 2025",
+  "start": "2025-07-14",
+  "end": "2025-07-18",
+  "timezone": "Europe/Belgrade",
+  "metadata": {
+    "icon": "https://textual.ru/mostar2025.png",
+    "links": [
+      {
+        "url": "https://2025.europe.foss4g.org/",
+        "title": "Website"
+      },
+      {
+        "url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2025/BirdsOfAFeather",
+        "title": "Birds of a Feather"
+      },
+      {
+        "url": "https://wiki.osgeo.org/wiki/FOSS4G-Europe-2025/CommunitySprint",
+        "title": "Community Sprint"
+      },
+      {
+        "url": "https://2025.europe.foss4g.org/sponsors/",
+        "title": "Sponsors"
+      }
+    ],
+    "rooms": [
+      {
+        "name": "PA..|PL..",
+        "show_name": "Faculty of Humanities and Social Sciences",
+        "latlon": [43.344169, 17.797409]
+      },
+      {
+        "name": "KOS",
+        "show_name": "Hrvatski dom Herceg Stjepan Kosača",
+        "latlon": [43.342265, 17.802576]
+      },
+      {
+        "name": "EL11",
+        "show_name": "Faculty of Economics",
+        "latlon": [43.344195, 17.796311]
+      },
+      {
+        "name": "SA0.",
+        "show_name": "Socratus Amphitheatre",
+        "latlon": [43.344128, 17.796726]
+      },
+      {
+        "name": "CA01",
+        "show_name": "Faculty of Civil Engineering",
+        "latlon": [43.346437, 17.796721]
+      },
+      {
+        "name": "Restaurant Del Rio",
+        "latlon": [43.348588, 17.810125]
+      },
+      {
+        "name": "Charlie Bar & Snack",
+        "latlon": [43.344045, 17.79499]
+      },
+      {
+        "name": "Pavarotti Music Centre",
+        "latlon": [43.334823, 17.817494]
+      }
+    ]
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "giggity"
+version = "0.1.0"
+description = "Giggity Tools"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "dulwich>=0.22.8",
+    "jsonschema>=4.23.0",
+    "pillow>=11.2.1",
+    "urllib3>=2.4.0",
+]


### PR DESCRIPTION
This adds an entry for FOSS4G Europe 2025 conference in Mostar. As usual, I've set up schedule merging.

Also I've updated `.gitignore` for some Python developer by-products, and added `pyproject.toml` if you don't mind, so one can do `uv run tools/menu-ci.py` and not deal with looking up dependencies.