### PR TITLE
Fix Debconf 25 indentation

### DIFF
--- a/menu/debconf25.json
+++ b/menu/debconf25.json
@@ -20,7 +20,7 @@
                 "url": "https://debconf25.debconf.org/about/coc/",
                 "title": "Code of Conduct"
             },
-	                {
+            {
                 "url": "https://debconf25.debconf.org/about/debcamp/",
                 "title": "DebCamp"
             },


### PR DESCRIPTION
The broken indentation of Debconf 25 also affects the merger which updates the menu.json on ggt.gaa.st. This provides an easy fix so that the ci/cd can run again