### PR TITLE
Add Open Source Summit Europe 2025

### DIFF
--- a/menu/oss_eu_2025.json
+++ b/menu/oss_eu_2025.json
@@ -1,0 +1,16 @@
+{
+	"version": 2025081500,
+	"title": "Open Source Summit Europe 2025",
+	"url": "https://osseu2025.sched.com/all.ics",
+	"start": "2025-08-25",
+	"end": "2025-08-27",
+	"timezone": "Europe/Amsterdam",
+	"metadata": {
+		"links": [
+			{
+				"url": "https://events.linuxfoundation.org/open-source-summit-europe/",
+				"title": "OSSEU Website"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Room names are a bit tedious since they all include an ", Amsterdam, Netherlands" but otherwise works pretty well.