### PR TITLE
[2025-11-01] Correct title casing

### DIFF
--- a/menu/openalt_2025.json
+++ b/menu/openalt_2025.json
@@ -1,5 +1,5 @@
 {
-	"version": 2025102700,
+	"version": 2025103000,
 	"url": "https://talks.openalt.cz/openalt-2025/schedule/export/schedule.xml",
 	"title": "OpenAlt 2025",
 	"start": "2025-11-01",


### PR DESCRIPTION
The name OpenAlt is a combination of the words Open and Alternatives. It’s not an abbreviation, and the correct capitalization is OpenAlt, not OpenALT.