### PR TITLE
[2026-03-14] IETF Shenzhen

### DIFF
--- a/menu/ietf125.json
+++ b/menu/ietf125.json
@@ -1,0 +1,17 @@
+{
+	"version": 2026022501,
+	"url": "https://datatracker.ietf.org/meeting/125/agenda.ics",
+	"title": "IETF 125 Shenzhen",
+	"start": "2026-03-14",
+	"end": "2026-03-20",
+	"timezone": "Asia/Shanghai",
+	"refresh_interval": 86400,
+	"metadata": {
+		"links": [
+			{
+				"url": "https://www.ietf.org/meeting/125/",
+				"title": "Website"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Please add. A few of us do use Giggitty while at the meeting. Thanks!

(May I add the next half-dozen IETF meetings in one go, even if the URLs don't exist yet?)
