### PR TITLE
[2026-06-04] fix: use the gpn24 schedule.xml with everything

### DIFF
--- a/menu/gpn24.json
+++ b/menu/gpn24.json
@@ -1,7 +1,7 @@
 {
-  "version": 2026051700,
-  "url": "https://cfp.gulas.ch/gpn24/schedule/export/schedule.xml",
-  "title": "24. Gulaschprogrammiernacht",
+  "version": 2026053000,
+  "url": "https://cfp.gulas.ch/merged/GPN24/everything.schedule.xml",
+  "title": "24. Gulaschprogrammiernacht (everything)",
   "start": "2026-06-04",
   "end": "2026-06-07",
   "timezone": "Europe/Berlin",


### PR DESCRIPTION
This is a merged schedule.xml for gpn24, including the lounge schedule (and possibly other events like gulasch kitchen etc.)

I hope I got the Version field right?