### PR TITLE
Update pyproject.toml and add a check for non-XML/ICS files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "giggity"
-version = "0.1.0"
+version = "0.2.0"
 description = "Giggity Tools"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "dulwich>=0.22.8",
-    "jsonschema>=4.23.0",
-    "pillow>=11.2.1",
-    "urllib3>=2.4.0",
+    "dulwich>=1.2.6",
+    "json5>=0.14.0",
+    "jsonschema>=4.26.0",
+    "pillow>=12.2.0",
+    "urllib3>=2.7.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Giggity Tools"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "dulwich>=1.2.6",
+    "dulwich>=0.24.10",
     "json5>=0.14.0",
     "jsonschema>=4.26.0",
     "pillow>=12.2.0",

--- a/tools/menu-ci.py
+++ b/tools/menu-ci.py
@@ -277,7 +277,10 @@ def validate_entry(e):
 	# Forced to use GET not HEAD even though I don't need the data because for
 	# example the retarded CCC server refuses HEAD requests.
 	try:
-		http.fetch(e["url"])
+		content = http.fetch(e["url"])
+		leader = None if not isinstance(content, bytes) else content.decode()[:16]
+		if not leader or (leader[:6] != '<?xml ' and leader[:6] != 'BEGIN:'):
+			ret.append("URL should reference an XML or an ICS file: %s" % e["url"])
 		ret += validate_url(e["url"])
 	except FetchError as err:
 		ret.append("Could not fetch %s %s: %s" % (e["title"], e["url"], err))


### PR DESCRIPTION
subj. Would allow running `uv run tools/menu-ci.py` and also catch issues like I had in #502.