### PR TITLE
[2026-07-18] IETF 126, starting in two weeks

### DIFF
--- a/menu/ietf126.json
+++ b/menu/ietf126.json
@@ -1,0 +1,17 @@
+{
+	"version": 2026070301,
+	"url": "https://datatracker.ietf.org/meeting/126/agenda.ics",
+	"title": "IETF 126 Vienna",
+	"start": "2026-07-18",
+	"end": "2026-07-24",
+	"timezone": "Europe/Berlin",
+	"refresh_interval": 86400,
+	"metadata": {
+		"links": [
+			{
+				"url": "https://www.ietf.org/meeting/126/",
+				"title": "Website"
+			}
+		]
+	}
+}


### PR DESCRIPTION
I'll try to add 127 as soon as the agenda is published.

(I'm a little late this time.)