### PR TITLE
[2026-07-13] Add DebConf 26

### DIFF
--- a/menu/debconf26.json
+++ b/menu/debconf26.json
@@ -1,16 +1,16 @@
 {
-	"version": 2026071401,
-	"url": "https://debconf26.debconf.org/schedule/pentabarf.xml",
-	"title": "DebConf 26",
-	"start": "2026-07-13",
-	"end": "2026-07-25",
-	"timezone": "America/Argentina/Cordoba",
-	"metadata": {
-		"icon": "https://debconf26.debconf.org/static/img/favicon/favicon-196.png",
-		"links": [
-			{
-				"url": "https://debconf26.debconf.org/",
-				"title": "DebConf 26"
+    "version": 2026071401,
+    "url": "https://debconf26.debconf.org/schedule/pentabarf.xml",
+    "title": "DebConf 26",
+    "start": "2026-07-13",
+    "end": "2026-07-25",
+    "timezone": "America/Argentina/Cordoba",
+    "metadata": {
+        "icon": "https://debconf26.debconf.org/static/img/favicon/favicon-196.png",
+        "links": [
+            {
+                "url": "https://debconf26.debconf.org/",
+                "title": "DebConf 26"
             },
             {
                 "title": "Wiki",
@@ -24,6 +24,6 @@
                 "url": "https://debconf26.debconf.org/about/debcamp/",
                 "title": "DebCamp"
             }
-		]
-	}
+        ]
+    }
 }

--- a/menu/debconf26.json
+++ b/menu/debconf26.json
@@ -1,12 +1,12 @@
 {
-	"version": 2019122000,
+	"version": 2026071401,
 	"url": "https://debconf26.debconf.org/schedule/pentabarf.xml",
 	"title": "DebConf 26",
 	"start": "2026-07-13",
 	"end": "2026-07-25",
 	"timezone": "America/Argentina/Cordoba",
 	"metadata": {
-		"icon": "https://debconf26.debconf.org/static/img/logo.8224b7f40c56.png",
+		"icon": "https://debconf26.debconf.org/static/img/favicon/favicon-196.png",
 		"links": [
 			{
 				"url": "https://debconf26.debconf.org/",
@@ -23,11 +23,7 @@
             {
                 "url": "https://debconf26.debconf.org/about/debcamp/",
                 "title": "DebCamp"
-            },
-            {
-                "url": "https://debconf26.debconf.org/static/img/venue-map.png",
-                "title": "Map"
-			}
+            }
 		]
 	}
 }

--- a/menu/debconf26.json
+++ b/menu/debconf26.json
@@ -1,0 +1,33 @@
+{
+	"version": 2019122000,
+	"url": "https://debconf26.debconf.org/schedule/pentabarf.xml",
+	"title": "DebConf 26",
+	"start": "2026-07-13",
+	"end": "2026-07-25",
+	"timezone": "America/Argentina/Cordoba",
+	"metadata": {
+		"icon": "https://debconf26.debconf.org/static/img/logo.8224b7f40c56.png",
+		"links": [
+			{
+				"url": "https://debconf26.debconf.org/",
+				"title": "DebConf 26"
+            },
+            {
+                "title": "Wiki",
+                "url": "https://wiki.debian.org/DebConf/26"
+            },
+            {
+                "url": "https://debconf26.debconf.org/about/coc/",
+                "title": "Code of Conduct"
+            },
+            {
+                "url": "https://debconf26.debconf.org/about/debcamp/",
+                "title": "DebCamp"
+            },
+            {
+                "url": "https://debconf26.debconf.org/static/img/venue-map.png",
+                "title": "Map"
+			}
+		]
+	}
+}


### PR DESCRIPTION
The 27th Debian Conference. Happening in Santa Fe, Argentina.